### PR TITLE
Fix for toLowerCase ist not A function

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -470,8 +470,8 @@ define(["TFS/WorkItemTracking/Services", "TFS/WorkItemTracking/RestClient", "TFS
         function matchField(fieldName, currentWorkItem, filterElement) {
             return (
                 typeof (filterElement[fieldName]) === "undefined" ||
-                (!Array.isArray(filterElement[fieldName].toLowerCase()) && filterElement[fieldName].toLowerCase() === currentWorkItem[fieldName].toLowerCase()) ||
-                (Array.isArray(filterElement[fieldName].toLowerCase()) && arraysEqual(filterElement[fieldName], currentWorkItem[fieldName]))
+                (!Array.isArray(filterElement[fieldName]) && filterElement[fieldName].toLowerCase() === currentWorkItem[fieldName].toLowerCase()) ||
+                (Array.isArray(filterElement[fieldName]) && arraysEqual(filterElement[fieldName], currentWorkItem[fieldName]))
             );
         }
 


### PR DESCRIPTION
Array.isArray(filterElement[fieldName] should not call .toLower() inside.
If you compare tags for example then this run into an error.